### PR TITLE
escape newlines

### DIFF
--- a/lib/logfmtr/base.rb
+++ b/lib/logfmtr/base.rb
@@ -8,7 +8,8 @@ module Logfmtr
       if msg.is_a? Hash
         msg_str = logfmtify_hash(msg)
       else
-        msg_str = %Q[msg=#{add_quotes(msg)}]
+        msg = add_quotes(escape_newlines(msg))
+        msg_str = %Q[msg=#{msg}]
       end
 
       %Q[level=#{severity} datetime="#{datetime.strftime(@datetime_format)}" progname=#{progname} #{msg_str}\n]
@@ -18,7 +19,8 @@ module Logfmtr
 
     def logfmtify_hash(message)
       message.collect do |key, value|
-        %Q[#{key}=#{add_quotes(value)}]
+        value = add_quotes(escape_newlines(value))
+        %Q[#{key}=#{value}]
       end.join(' ')
     end
 
@@ -36,6 +38,10 @@ module Logfmtr
       else
         false
       end
+    end
+
+    def escape_newlines(message)
+      message.to_s.gsub(/\n/, "\\n")
     end
   end
 end

--- a/spec/lib/logfmtr_spec.rb
+++ b/spec/lib/logfmtr_spec.rb
@@ -39,7 +39,13 @@ describe Logfmtr::LogfmtLogger do
   end
 
   it "puts quotes around values that need them" do
+    dt_format = default_datetime_format
+    expect { log_quotes_needed(dt_format) }.to output(%Q[level=INFO datetime="#{Time.now.strftime(dt_format)}" progname= msg="Testing some /stuff"\n]).to_stdout
+  end
 
+  it "escapes new lines in values" do
+    dt_format = default_datetime_format
+    expect { escape_newlines_needed(dt_format) }.to output(%Q[level=INFO datetime="#{Time.now.strftime(dt_format)}" progname= msg="Testing some\\nstuff"\n]).to_stdout
   end
 end
 
@@ -70,6 +76,16 @@ end
 def log_hash(datetime_format)
   logger = logger_init(datetime_format)
   logger.info ({ one: 1, two: 2, three: "!@#$$%^&*}" })
+end
+
+def log_quotes_needed(datetime_format)
+  logger = logger_init(datetime_format)
+  logger.info ("Testing some /stuff")
+end
+
+def escape_newlines_needed(datetime_format)
+  logger = logger_init(datetime_format)
+  logger.info ("Testing some\nstuff")
 end
 
 def logger_init(datetime_format)


### PR DESCRIPTION
An issue would occur when a log message was sent that had newline characters. Rather than logging this message with the newline characters escaped, the message would be split into multiple lines on stdout. This prevented other services (hoseclamp and SumoLogic) from properly recognizing the logs.

This PR replaces all newline characters with the string literal '\n'.